### PR TITLE
Quality of life functions to define contexts and actors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test test-list-ext
 
-LIGO_COMPILER_VERSION:=0.48.0
+LIGO_COMPILER_VERSION:=0.49.0
 TEZOS_PROTOCOL:=jakarta
 LIGO_DOCKER := docker run --rm  -v $(PWD):$(PWD) -w $(PWD) ligolang/ligo:$(LIGO_COMPILER_VERSION)
 

--- a/examples/auction/test/test_auction_sc.mligo
+++ b/examples/auction/test/test_auction_sc.mligo
@@ -30,7 +30,7 @@ let case_happy_path =
     "bid"
     "when everything is ok, it should upgrade the leader"
     (fun (level: Breath.Logger.level) ->
-      let (_, (alice, bob, carol)) = Breath.Context.init_default () in
+      let alice, bob, carol = Breath.Context.init_3_actors () in
       let contract = Util.originate level in
 
       let alice_action = Breath.Context.act_as alice (Util.bid contract 1tez) in
@@ -53,7 +53,7 @@ let case_leader_try_to_be_upgraded_twice =
     "bid"
     "when the leader try to reupgrade the storage it should raise an error"
     (fun (level: Breath.Logger.level) ->
-      let (_, (alice, _, _)) = Breath.Context.init_default () in
+      let alice = Breath.Context.init_1_actor () in
       let contract = Util.originate level in
 
       let alice_fst_action = Breath.Context.act_as alice (Util.bid contract 1tez) in
@@ -74,7 +74,7 @@ let case_try_to_upgrade_with_a_lower_amount =
     "bid"
     "when a challenger try to upgrade the storage with a lower amount it should raise an error"
     (fun (level: Breath.Logger.level) ->
-      let (_, (alice, bob, _)) = Breath.Context.init_default () in
+      let (alice, bob) = Breath.Context.init_2_actors () in
       let contract = Util.originate level in
 
       let alice_action = Breath.Context.act_as alice (Util.bid contract 2tez) in
@@ -95,7 +95,7 @@ let case_try_to_upgrade_with_a_null_amount =
     "bid"
     "when a challenger try to upgrade the storage without tez, it should raise an error"
     (fun (level: Breath.Logger.level) ->
-      let (_, (alice, _, _)) = Breath.Context.init_default () in
+      let alice = Breath.Context.init_1_actor () in
       let contract = Util.originate level in
 
       let alice_action = Breath.Context.act_as alice (Util.bid contract 0tez) in

--- a/lib/context.mligo
+++ b/lib/context.mligo
@@ -28,6 +28,16 @@ type actor = {
 ; address: address
 }
 
+let default_actors = [
+    ("Baker", 10000000000tez)
+  ; ("Alice", 4000000tez)
+  ; ("Bob", 2000000tez)
+  ; ("Carol", 8000000tez)
+  ; ("David", 8000000tez)
+  ; ("Eve", 8000000tez)
+  ; ("Frank", 8000000tez)
+]
+
 (** [init actors] initialize bootstrap accounts. *)
 let init_with (actors: (string * tez) list) : actor list =
   let number_of_accounts = List.size actors in
@@ -49,20 +59,83 @@ let init_with (actors: (string * tez) list) : actor list =
    in
    Util.rev actors
 
-(** [init_default ()] will initialize a context with four participant,
+(** [init_with_default n] initializes a context with [n] participants,
+    the first one is the baker and the other are regular participants. *)
+let init_with_default (n : int) : actor list =
+  let actors = Util.take n default_actors in
+  init_with actors
+
+(** [init_default ()] will initialize a context with four participants,
     the first one is the baker and the other are regular participants. *)
 let init_default () : actor * (actor * actor * actor) =
-  let actors = init_with [
-    ("Baker", 10000000000tez)
-  ; ("Alice", 4000000tez)
-  ; ("Bob", 2000000tez)
-  ; ("Carol", 8000000tez)
-  ]
-  in
+  let actors = init_with_default 4 in
   match actors with
   | [baker; alice; bob; carol] ->
     let () = Test.set_baker baker.address in
     baker, (alice, bob, carol)
+  | _ -> Test.failwith "unreachable case"
+
+(** [init_with_baker ()] initializes a context with one baker and returns
+    it. *)
+let init_with_baker () : actor =
+  match init_with_default 1 with
+  | [baker] ->
+    let () = Test.set_baker baker.address in
+    baker
+  | _ -> Test.failwith "unreachable case"
+
+(** [init_1_actor ()] initializes a context with one baker and one participant,
+    and returns this participant. *)
+let init_1_actor () : actor =
+  match init_with_default 2 with
+  | [baker; alice] ->
+    let () = Test.set_baker baker.address in
+    alice
+  | _ -> Test.failwith "unreachable case"
+
+(** [init_2_actors ()] initializes a context with one baker and two
+    participants, and returns these participants. *)
+let init_2_actors () : (actor * actor) =
+  match init_with_default 3 with
+  | [baker; alice; bob] ->
+    let () = Test.set_baker baker.address in
+    (alice, bob)
+  | _ -> Test.failwith "unreachable case"
+
+(** [init_3_actors ()] initializes a context with one baker and three
+    participants, and returns these participants. *)
+let init_3_actors () : (actor * actor * actor) =
+  match init_with_default 4 with
+  | [baker; alice; bob; carol] ->
+    let () = Test.set_baker baker.address in
+    (alice, bob, carol)
+  | _ -> Test.failwith "unreachable case"
+
+(** [init_4_actors ()] initializes a context with one baker and four
+    participants, and returns these participants. *)
+let init_4_actors () : (actor * actor * actor * actor) =
+  match init_with_default 5 with
+  | [baker; alice; bob; carol; dave] ->
+    let () = Test.set_baker baker.address in
+    (alice, bob, carol, dave)
+  | _ -> Test.failwith "unreachable case"
+
+(** [init_5_actors ()] initializes a context with one baker and four
+    participants, and returns these participants. *)
+let init_5_actors () : (actor * actor * actor * actor * actor) =
+  match init_with_default 6 with
+  | [baker; alice; bob; carol; dave; eve] ->
+    let () = Test.set_baker baker.address in
+    (alice, bob, carol, dave, eve)
+  | _ -> Test.failwith "unreachable case"
+
+(** [init_6_actors ()] initializes a context with one baker and six
+    participants, and returns these participants. *)
+let init_6_actors () : (actor * actor * actor * actor * actor * actor) =
+  match init_with_default 7 with
+  | [baker; alice; bob; carol; dave; eve; frank] ->
+    let () = Test.set_baker baker.address in
+    (alice, bob, carol, dave, eve, frank)
   | _ -> Test.failwith "unreachable case"
 
 (** [act_as actor f] will perform the operation [f] in the POV of the given [actor]. *)

--- a/lib/util.mligo
+++ b/lib/util.mligo
@@ -73,3 +73,16 @@ let concat (type a) (left: a list) (right: a list) : a list =
 (** [rev list] should return the same list reversed. *)
 let rev (type a) (list: a list) : a list =
   List.fold_left (fun (xs, x : a list * a) -> x :: xs) ([] : a list) list
+
+(** [take k list] returns the list of the k first elements of [list] and fails
+    if k is negative or if the list is too short *)
+let take (type a) (k : int) (xs : a list) : (a list) =
+  let rec aux (type a) (i : int) (xs : a list) (acc : a list) : a list =
+    if i < 0 then failwith "Invalid argument"
+    else if i = 0 then acc
+    else match xs with
+      | [] -> failwith "Invalid argument: list is too short"
+      | y::ys -> aux (i-1) ys (y :: acc)
+  in
+  rev (aux k xs ([] : a list))
+


### PR DESCRIPTION
Has this ever happened to you? You are patiently at home, writing tests for your smart contracts, when suddenly you need a context and one actor to simulate the deployment! You start writing

```
  let alice = Breath.Context.init_default () in
```
but oh no! `init_default` actually returns a baker and _three_ actors! Well look no further, this PR fixes this and defines

```
init_with_baker () : actor
init_1_actor () : actor
init_2_actors () : (actor * actor)
init_3_actors () : (actor * actor * actor)
init_4_actors () : (actor * actor * actor * actor)
init_5_actors () : (actor * actor * actor * actor * actor)
init_6_actors () : (actor * actor * actor * actor * actor * actor)
```

I'm opening now to discuss things such as the names of the function, the number of participants, and the importance of leaving out the baker or not. I'm open to writing more tests to cover these functions as well.