### PR TITLE
feat: support origination of curried contract parameter

### DIFF
--- a/examples/auction/src/auction_sc.mligo
+++ b/examples/auction/src/auction_sc.mligo
@@ -41,7 +41,7 @@ let bid (storage: storage) (quantity: tez) (user_address: address) : storage =
     let () = if current_leader_amount >= quantity then failwith "Amount should be greater" in
     Some { current_leader_address = user_address; current_leader_amount = quantity }
 
-let main (action, storage: entrypoint * storage) : applied =
+let main (action: entrypoint) (storage: storage) : applied =
   match action with
   | Bid ->
     let quantity = Tezos.get_amount () in

--- a/examples/ticket_factory/test/util.mligo
+++ b/examples/ticket_factory/test/util.mligo
@@ -27,7 +27,7 @@
 type originated = Breath.Contract.originated
 
 let originate_mint (level: Breath.Logger.level) (pl: bytes) (min_amount: tez) () =
-  Breath.Contract.originate
+  Breath.Contract.originate_uncurried
     level
     "mint_sc"
     Mint.main
@@ -46,7 +46,7 @@ let originate_oven_with
       let (_, (_, qty)), fresh = Tezos.read_ticket t in
       (Some fresh, qty)
   in
-  Breath.Contract.originate
+  Breath.Contract.originate_uncurried
     level
     ("oven_sc_" ^ actor.name)
     Oven.main

--- a/lib/contract.mligo
+++ b/lib/contract.mligo
@@ -36,12 +36,33 @@ let originate
     (type a b)
     (level: Logger.level)
     (name: string)
+    (main: (a -> b -> (operation list * b)))
+    (storage: b)
+    (quantity: tez) : (a, b) originated =
+  let typed_address, _, _ = Test.originate main storage quantity in
+  let contract = Test.to_contract typed_address in
+  let address = Tezos.address contract in
+
+  let () =
+    Logger.log level ("originated smart contract", name, address, storage, quantity)
+  in
+  { originated_typed_address = typed_address
+  ; originated_contract = contract
+  ; originated_address = address }
+
+(** [originate_uncurried level name f storage quantity] will originate the smart-contract
+    [f] (which is a main entry point) and will provision it using [quantity] and
+    with [storage] as a default storage value. *)
+let originate_uncurried
+    (type a b)
+    (level: Logger.level)
+    (name: string)
     (main: (a * b -> (operation list * b)))
     (storage: b)
     (quantity: tez) : (a, b) originated =
-  let address = Test.originate_contract (Test.compile_contract main) (Test.eval storage) quantity in
-  let typed_address = Test.cast_address address in
+  let typed_address, _, _ = Test.originate_uncurried main storage quantity in
   let contract = Test.to_contract typed_address in
+  let address = Tezos.address contract in
 
   let () =
     Logger.log level ("originated smart contract", name, address, storage, quantity)


### PR DESCRIPTION
Hello, following https://gitlab.com/ligolang/ligo/-/merge_requests/2241#changelog

The convention, for cameligo seems to write contract parameter in curried form. 

But Breathalyzer only allows origination of uncurried parameter.

In this MR, I replaced `Test.originate_contract` by `Test.originate` and `Test.originate_uncurried` because `Test.originate_contract` depends on [`Test.compile_contract`](https://gitlab.com/ligolang/ligo/-/blob/dev/src/main/build/ligo_lib/std_lib.mligo#L280) that can only handle uncurried parameter.