### PR TITLE
Module origination

### DIFF
--- a/lib/assert.mligo
+++ b/lib/assert.mligo
@@ -22,7 +22,7 @@
 
 #import "result.mligo" "Result"
 
-let fail_with (message : string) =
+let fail_with (message: string) =
   Result.fail_with ("Assertion failed: " ^ message)
 
 (** Some common assertions. *)

--- a/lib/context.mligo
+++ b/lib/context.mligo
@@ -30,7 +30,7 @@ type actor = {
 ; address: address
 }
 
-(** [init actors] initialize bootstrap accounts. *)
+(** [init actors] initializes bootstrap accounts. *)
 let init_with (actors: (string * tez) list) : actor list =
   let number_of_accounts = List.size actors in
   let default_amounts =
@@ -51,8 +51,8 @@ let init_with (actors: (string * tez) list) : actor list =
    in
    Util.rev actors
 
-(** [init_default ()] will initialize a context with four participant,
-    the first one is the baker and the other are regular participants. *)
+(** [init_default ()] initializes a context with four participant, the first one
+    being the baker and the others regular accounts. *)
 let init_default () : actor * (actor * actor * actor) =
   let actors = init_with [
     ("Baker", 10000000000tez)
@@ -67,7 +67,7 @@ let init_default () : actor * (actor * actor * actor) =
     baker, (alice, bob, carol)
   | _ -> Test.failwith "unreachable case"
 
-(** [act_as actor f] will perform the operation [f] in the POV of the given [actor]. *)
+(** [act_as actor f] performs the operation [f] as [actor]. *)
 let act_as (type a) (actor: actor) (handler : unit -> a) : a =
   let old_source = Tezos.get_source () in
   let address = actor.address in
@@ -76,6 +76,8 @@ let act_as (type a) (actor: actor) (handler : unit -> a) : a =
   let () = Test.set_source old_source in
   result
 
+(** [call_as actor contract parameter] performs the [contract] call [f] as
+    [actor]. *)
 let call_as
   (type a b)
   (actor: actor)

--- a/lib/context.mligo
+++ b/lib/context.mligo
@@ -21,6 +21,8 @@
    SOFTWARE. *)
 
 #import "util.mligo" "Util"
+#import "contract.mligo" "Contract"
+#import "result.mligo" "Result"
 
 type actor = {
   name : string
@@ -73,3 +75,10 @@ let act_as (type a) (actor: actor) (handler : unit -> a) : a =
   let result = handler () in
   let () = Test.set_source old_source in
   result
+
+let call_as
+  (type a b)
+  (actor: actor)
+  (originated: (a, b) Contract.originated)
+  (parameter: a) : Result.result =
+  act_as actor (fun () -> Contract.call originated parameter)

--- a/lib/contract.mligo
+++ b/lib/contract.mligo
@@ -71,6 +71,28 @@ let originate_uncurried
   ; originated_contract = contract
   ; originated_address = address }
 
+(** [originate_module level name module storage quantity] will originate the
+    smart-contract from the module [module] and will provision it using [quantity]
+    and with [storage] as a default storage value. Use the [contract_of] keyword to
+    get a module_contract out of a module. Use this function to originate a contract
+    with views. *)
+let originate_module
+  (type a b)
+  (level: Logger.level)
+  (name: string)
+  (contract: (a, b) module_contract)
+  (storage: b)
+  (quantity: tez) : (a, b) originated =
+  let typed_address, _, _ = Test.originate_module contract storage quantity in
+  let contract = Test.to_contract typed_address in
+  let address = Tezos.address contract in
+
+  let () =
+    Logger.log level ("originated smart contract", name, address, storage, quantity)
+  in
+  { originated_typed_address = typed_address
+  ; originated_contract = contract
+  ; originated_address = address }
 
 (** [transfer_to contract parameter amount] will transfer amount to an originated SC. *)
 let transfer_to
@@ -92,6 +114,13 @@ let transfer_with_entrypoint_to
   let contract = Test.to_entrypoint entrypoint originated.originated_typed_address in
   Result.try_with
     (fun () -> Test.transfer_to_contract contract parameter fund)
+
+(** TODO *)
+let call
+  (type a b)
+  (originated: (a, b) originated)
+  (parameter: a) : Result.result =
+  transfer_to originated parameter 0tez
 
 (** [storage_of originated_contract] will retreive the storage of an originated smart-contract. *)
 let storage_of

--- a/lib/contract.mligo
+++ b/lib/contract.mligo
@@ -29,9 +29,9 @@ type ('a, 'b) originated = {
 ; originated_address : address
 }
 
-(** [originate level name f storage quantity] will originate the smart-contract
-    [f] (which is a main entry point) and will provision it using [quantity] and
-    with [storage] as a default storage value. *)
+(** [originate level name f storage quantity] originates the smart-contract [f]
+    (which is a main entry point) and provisions it using [quantity] and with
+    [storage] as a default storage value. *)
 let originate
     (type a b)
     (level: Logger.level)
@@ -50,9 +50,9 @@ let originate
   ; originated_contract = contract
   ; originated_address = address }
 
-(** [originate_uncurried level name f storage quantity] will originate the smart-contract
-    [f] (which is a main entry point) and will provision it using [quantity] and
-    with [storage] as a default storage value. *)
+(** [originate_uncurried level name f storage quantity] originates the
+    smart-contract [f] (which is a main entry point) and provisions it using
+    [quantity] and with [storage] as a default storage value. *)
 let originate_uncurried
     (type a b)
     (level: Logger.level)
@@ -71,11 +71,11 @@ let originate_uncurried
   ; originated_contract = contract
   ; originated_address = address }
 
-(** [originate_module level name module storage quantity] will originate the
-    smart-contract from the module [module] and will provision it using [quantity]
-    and with [storage] as a default storage value. Use the [contract_of] keyword to
-    get a module_contract out of a module. Use this function to originate a contract
-    with views. *)
+(** [originate_module level name module storage quantity] originates the
+    smart-contract from the module [module] and provisions it using [quantity]
+    and with [storage] as a default storage value. Use the [contract_of] keyword
+    to get a module_contract out of a module. Use this function to originate a
+    contract with views. *)
 let originate_module
   (type a b)
   (level: Logger.level)
@@ -94,7 +94,8 @@ let originate_module
   ; originated_contract = contract
   ; originated_address = address }
 
-(** [transfer_to contract parameter amount] will transfer amount to an originated SC. *)
+(** [transfer_to contract parameter amount] transfers amount to an
+    originated SC. *)
 let transfer_to
     (type a b)
     (originated: (a, b) originated)
@@ -104,7 +105,8 @@ let transfer_to
   Result.try_with
     (fun () -> Test.transfer_to_contract contract parameter fund)
 
-(** [transfer_with_entrypoint_to contract entrypoint parameter amount] will transfer amount to an originated SC. *)
+(** [transfer_with_entrypoint_to contract entrypoint parameter amount] transfers
+    [amount] to an originated SC. *)
 let transfer_with_entrypoint_to
     (type a b c)
     (originated: (a, b) originated)
@@ -115,21 +117,24 @@ let transfer_with_entrypoint_to
   Result.try_with
     (fun () -> Test.transfer_to_contract contract parameter fund)
 
-(** TODO *)
+(** [call contract parameter] calls [contract] with [parameter] without
+    transferring any tez. *)
 let call
   (type a b)
   (originated: (a, b) originated)
   (parameter: a) : Result.result =
   transfer_to originated parameter 0tez
 
-(** [storage_of originated_contract] will retreive the storage of an originated smart-contract. *)
+(** [storage_of originated_contract] retreives the storage of an originated
+    smart-contract. *)
 let storage_of
     (type a b)
     (originated: (a, b) originated) : b =
   let typed_address = originated.originated_typed_address in
   Test.get_storage typed_address
 
-(** [get_balance originated_contract] gives the current balance of a smart-contract. *)
+(** [balance_of originated_contract] returns the current balance of a
+    smart-contract. *)
 let balance_of
     (type a b)
     (originated: (a, b) originated) : tez =

--- a/test/simple_contract.jsligo
+++ b/test/simple_contract.jsligo
@@ -1,0 +1,18 @@
+type s = int;
+type ret = [list<operation>, s];
+
+@entry
+const increment = (delta : int, store : s) : ret =>
+  [list([]), store + delta];
+
+@entry
+const decrement = (delta : int, store : s) : ret =>
+  [list([]), store - delta];
+
+@entry
+const reset = (_ : unit, _ : s) : ret =>
+  [list([]), 0];
+
+@view
+const get_value = (_ : unit, s : s) : s =>
+  s

--- a/test/test_result.mligo
+++ b/test/test_result.mligo
@@ -111,7 +111,7 @@ let case_result_reduce_2 =
       in
       B.Assert.is_true "should be equal" (expected = computed))
 
-let case_result_reduce_2 =
+let case_result_reduce_3 =
   B.Model.case
     "reduce"
     "when there are some errors it should merge them"
@@ -136,4 +136,4 @@ let suite =
       case_result_and_then_lazy_2 ;
       case_result_reduce_1 ;
       case_result_reduce_2 ;
-      case_result_reduce_2 ]
+      case_result_reduce_3 ]


### PR DESCRIPTION
This PR adds support to originate a Ligo module, which has to use the `[@entry]`/`@entry` keyword, and can export views using the `[@view]`/`@view` keyword. It also adds handy shortcuts, a few minor fixes and gives an example of calling a view in the tests.

I'll add more examples of views in a different PR.