### PR TITLE
[❌ DO NOT MERGE] chore(deps): bump LIGO to version 1.5.0

### DIFF
--- a/lib/lib.mligo
+++ b/lib/lib.mligo
@@ -23,16 +23,23 @@
 (** The entrypoint of the test framework library. *)
 
 (** Re-export the [Logger module]. *)
+[@public]
 #import "logger.mligo" "Logger"
 
+[@public]
 #import "result.mligo" "Result"
 
+[@public]
 #import "model.mligo" "Model"
 
+[@public]
 #import "assert.mligo" "Assert"
 
+[@public]
 #import "expect.mligo" "Expect"
 
+[@public]
 #import "context.mligo" "Context"
 
+[@public] 
 #import "contract.mligo" "Contract"


### PR DESCRIPTION
**DO NOT MERGE UNTIL LIGO 1.5.0 IS RELEASED**

# Context

Related issues: [#2161](https://gitlab.com/ligolang/ligo/-/issues/2161)

Following [!3112](https://gitlab.com/ligolang/ligo/-/merge_requests/3112), breathalyzer library is no-longer usable -- this is due to the fact that modules that were previously exported using an `#import` no-longer get implicitly exported. 

# Description 

Adds `[@public]` to imports in the `lib.mligo` file to ensure all modules are correctly re-exported

# Manual Testing

```sh
cd ligo
git checkout dev
dune build -p ligo
cd ../breathalyzer
make test LIGO_CC=../ligo/_build/default/src/bin/runligo.exe
```